### PR TITLE
Use a property for the cli engine config that doesn't conflict with the rc module's added properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,12 @@ Example `.eslintoutputrc`
       "path": "tmp/junit.xml"
     }
   ],
-  "config": {}
+  "cliEngineConfig": {}
 }
 ```
-NB: 
+NB:
 
-- It is optional to also specify configs for the 
-eslint cliengine using the config property http://eslint.org/docs/developer-guide/nodejs-api#cliengine. However, it is recommended that you use the `.eslintrc`
+- It is optional to also specify configs for the eslint cliengine using the `cliEngineConfig` property. See http://eslint.org/docs/developer-guide/nodejs-api#cliengine for the options. However, it is recommended that you use the `.eslintrc`
 - file paths are relative to the current working directory
 
 ## Notes

--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const cwd = path.resolve(process.cwd());
 const cli = new CLIEngine(Object.assign({
   envs: ['browser', 'mocha'],
   useEslintrc: true,
-}, rc.config, { cwd }));
+}, rc.cliEngineConfig, { cwd }));
 
 const report = cli.executeOnFiles(rc.files || ['.']);
 


### PR DESCRIPTION
The `rc` module adds the `configs` and `config` properties to the returned object to let the caller know where it actually found the configuration. It looks like this:

```
{
  "port": 9000,
  "mode": "test",
  "foo": "barbar",
  "something": "else",
  "_": [],
  "config": "config.json",
  "configs": [
    "/Users/stephen/repos/conftest/.myapprc",
    "config.json"
  ]
}
```

Sadly, this stomps on any key named `config` from the actual configuration rc is trying to load. So, eslint-output's config option was getting overwritten by the rc library.

This change makes eslint-output use a different key, so it doesn't get overwritten. Woop woop.