### PR TITLE
Use `process.exitCode` to gracefully exit and allow async reporter tasks to complete

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,6 @@ formats.forEach((format) => {
 });
 
 if (report.errorCount > 0) {
-  process.exit(1);
+  process.exitCode = 1;
 }
 


### PR DESCRIPTION
Calling `process.exit()` kills our linter process and any callbacks inside the `formatter`s are potentially killed along with it. This prevents things like async file saving from completing properly, or whatever else those linters are up to.

We should set the error code, and then then everything has finished up we'll exit with that.